### PR TITLE
Allow spaces in argument values.

### DIFF
--- a/README
+++ b/README
@@ -32,6 +32,16 @@ becomes:
 
     http://mysite.com/rrdtool--start%20now-300s%20--end%20now%20DEF%3Ads0%3Dtest.rrd%3Areading%3AAVERAGE%20LINE1%3Ads0%2300FF00
 
+Spaces can be inlcuded in argument values by using the tilde character.
+For example, the title of the following example will be rendered as
+"Test Graph":
+
+    rrdtool graph --start now-300s \
+                  --end now \
+                  --tile Test~Graph \
+                  DEF:ds0=test.rrd:reading:AVERAGE \
+                  LINE1:ds0#00FF00
+
 The module supports all the features of your copy of RRDtool. It can output
 PNG, PDF, SVG, and EPS graphics (see the --imgformat option of rrdgraph(1)).
 

--- a/ngx_http_rrd_graph_module.c
+++ b/ngx_http_rrd_graph_module.c
@@ -189,6 +189,8 @@ ngx_http_rrd_graph_parse_uri(ngx_http_request_t *r, int *argc_ptr,
             *p = '\0';
             argv[argc++] = p+1;
         } else {
+            if (*p == '~')
+                *p = ' ';
             argv_len[argc-1]++;
         }
         p++;


### PR DESCRIPTION
Hi Evan,

I was very pleased to find your rrd graph module. However, I wasn't able to include spaces in graph titles, etc., so I patched the module to replace tildes with spaces. Here it is if you'd like to merge it in.

Thanks,
Jacob

---

This is a hack to allow spaces in argument values (for example, for
arguments like --title). The hack is to have the module substitute all
occurrences of tilde in the URI with spaces before passing the
arguments to rrdtool.

It comes at the cost of losing the ability to place literal tilde
characters in graph text, which is not likely to be a problem in
practice. If it is found to be a problem, perhaps the character to
substitue (or the feature altogether) could be controlled with a
module directive.
