### PR TITLE
Remove the quotation marks around strings from arguments.

### DIFF
--- a/ngx_http_rrd_graph_module.c
+++ b/ngx_http_rrd_graph_module.c
@@ -204,6 +204,14 @@ ngx_http_rrd_graph_parse_uri(ngx_http_request_t *r, int *argc_ptr,
         p++;
     }
 
+    for (i = 0; i < argc; i++) {
+        if (*argv[i] == '\"') {
+            argv[i] = argv[i] + 1;
+            argv_len[i] = argv_len[i] - 2;
+            argv[i][argv_len[i]] = '\0';
+        }
+    }
+
     conf = ngx_http_get_module_loc_conf(r, ngx_http_rrd_graph_module);
     /* splice in the RRD directory root */
     /* TODO guard against relative paths */


### PR DESCRIPTION
This prevents displaying the quotation marks in graph images. Issue #1
